### PR TITLE
修复权限过滤器执行两次的BUG

### DIFF
--- a/Shared/src/main/java/com/autobon/shared/Crypto.java
+++ b/Shared/src/main/java/com/autobon/shared/Crypto.java
@@ -26,7 +26,6 @@ public class Crypto {
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException ex) {
-            ex.printStackTrace();
             return "";
         }
     }
@@ -51,9 +50,7 @@ public class Crypto {
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(alignBytes(key, 16), "AES"));
             return new String(cipher.doFinal(Base64.getDecoder().decode(text)));
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+        } catch (Exception ex) {}
         return "";
     }
 

--- a/src/main/java/com/autobon/platform/config/SecurityConfig.java
+++ b/src/main/java/com/autobon/platform/config/SecurityConfig.java
@@ -2,7 +2,10 @@ package com.autobon.platform.config;
 
 import com.autobon.platform.security.TokenAuthenticationProcessingFilter;
 import com.autobon.platform.security.TokenAuthenticationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -24,6 +27,9 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableGlobalMethodSecurity(securedEnabled = true)
 @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Bean
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
@@ -33,7 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        TokenAuthenticationProcessingFilter filter = new TokenAuthenticationProcessingFilter(
+        TokenAuthenticationProcessingFilter filter = new TokenAuthenticationProcessingFilter(applicationContext,
                 new AntPathRequestMatcher("/api/**"));
         filter.setAuthenticationManager(authenticationManagerBean());
         http.addFilterBefore(filter, BasicAuthenticationFilter.class);

--- a/src/main/java/com/autobon/platform/config/SecurityConfig.java
+++ b/src/main/java/com/autobon/platform/config/SecurityConfig.java
@@ -31,17 +31,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         return authenticationManager;
     }
 
-    @Bean
-    public TokenAuthenticationProcessingFilter authenticationProcessingFilter() throws Exception {
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
         TokenAuthenticationProcessingFilter filter = new TokenAuthenticationProcessingFilter(
                 new AntPathRequestMatcher("/api/**"));
         filter.setAuthenticationManager(authenticationManagerBean());
-        return filter;
-    }
+        http.addFilterBefore(filter, BasicAuthenticationFilter.class);
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
-        http.addFilterBefore(authenticationProcessingFilter(), BasicAuthenticationFilter.class);
         http.authorizeRequests().antMatchers(
                 "/api/mobile/*/login",
                 "/api/mobile/*/register",

--- a/src/main/java/com/autobon/platform/security/TokenAuthenticationProcessingFilter.java
+++ b/src/main/java/com/autobon/platform/security/TokenAuthenticationProcessingFilter.java
@@ -6,8 +6,7 @@ import com.autobon.staff.entity.Staff;
 import com.autobon.staff.service.StaffService;
 import com.autobon.technician.entity.Technician;
 import com.autobon.technician.service.TechnicianService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
@@ -29,15 +28,12 @@ import java.util.Date;
  * Created by dave on 16/2/16.
  */
 public class TokenAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
-    @Autowired
-    private TechnicianService technicianService;
-    @Autowired
-    private StaffService staffService;
-    @Autowired
-    private CooperatorService cooperatorService;
+    private ApplicationContext applicationContext;
 
-    public TokenAuthenticationProcessingFilter(RequestMatcher requiresAuthenticationRequestMatcher) {
+    public TokenAuthenticationProcessingFilter(ApplicationContext applicationContext,
+            RequestMatcher requiresAuthenticationRequestMatcher) {
         super(requiresAuthenticationRequestMatcher);
+        this.applicationContext = applicationContext;
         this.setContinueChainBeforeSuccessfulAuthentication(true);
     }
 
@@ -54,6 +50,7 @@ public class TokenAuthenticationProcessingFilter extends AbstractAuthenticationP
         if (token.startsWith("technician:")) {
             int id = Technician.decodeToken(token);
             if (id > 0) {
+                TechnicianService technicianService = applicationContext.getBean(TechnicianService.class);
                 user = technicianService.get(id);
                 if (user != null) {
                     Technician technician = (Technician) user;
@@ -64,10 +61,10 @@ public class TokenAuthenticationProcessingFilter extends AbstractAuthenticationP
             }
         } else if (token.startsWith("cooperator:")) {
             int id = Cooperator.decodeToken(token);
-            if (id > 0) user = cooperatorService.get(id);
+            if (id > 0) user = applicationContext.getBean(CooperatorService.class).get(id);
         } else if (token.startsWith("staff:")) {
             int id = Staff.decodeToken(token);
-            if (id > 0) user = staffService.get(id);
+            if (id > 0) user = applicationContext.getBean(StaffService.class).get(id);
         }
 
         if (user == null) {

--- a/src/main/java/com/autobon/platform/security/TokenAuthenticationProcessingFilter.java
+++ b/src/main/java/com/autobon/platform/security/TokenAuthenticationProcessingFilter.java
@@ -62,13 +62,15 @@ public class TokenAuthenticationProcessingFilter extends AbstractAuthenticationP
                     technicianService.save(technician);
                 }
             }
-        }else if (token.startsWith("cooperator:")) {
+        } else if (token.startsWith("cooperator:")) {
             int id = Cooperator.decodeToken(token);
             if (id > 0) user = cooperatorService.get(id);
         } else if (token.startsWith("staff:")) {
             int id = Staff.decodeToken(token);
             if (id > 0) user = staffService.get(id);
-        } else {
+        }
+
+        if (user == null) {
             GrantedAuthority authority = new GrantedAuthority() {
                 @Override
                 public String getAuthority() {


### PR DESCRIPTION
在声明过滤器为Bean的同时，将过滤器加入了Spring Security的http过滤器中，导致重复执行。
